### PR TITLE
docs(aws): add ELB and ASG study notes for Cloud Practitioner exam

### DIFF
--- a/aws-cloud-practitioner/ec2-elb-asg.md
+++ b/aws-cloud-practitioner/ec2-elb-asg.md
@@ -153,7 +153,7 @@ Operates at Layer 4 (transport layer) for ultra-high performance and static IP r
 
 **Cross-zone load balancing**: Disabled by default (can enable)
 
-**Routing**: Uses 5-tuple flow hash (protocol, source/dest IP, source/dest port, TCP sequence)
+**Routing**: Uses 5-tuple flow hash (protocol, source IP, destination IP, source port, destination port)
 
 > [↑ Back to Table of Contents](#table-of-contents)
 
@@ -172,11 +172,7 @@ Operates at Layer 3 (network layer) for routing traffic through third-party secu
 - Deep packet inspection
 - Network traffic analysis
 
-**How it works**: GWLB acts as a transparent network gateway. Traffic flows: source -> GWLB -> security appliance for inspection -> GWLB -> destination (if safe).
-
-> [!NOTE]
->
-> GWLB does NOT terminate connections - it is pass-through only.
+**How it works**: GWLB acts as a transparent network gateway. Traffic flows: source -> GWLB -> security appliance for inspection -> GWLB -> destination (if safe). GWLB does NOT terminate connections - it is pass-through only.
 
 **Cross-zone load balancing**: Disabled by default
 


### PR DESCRIPTION
closes #8

CHANGES
- Add comprehensive notes on EC2 scalability concepts (vertical, horizontal, elasticity, agility, high availability)
- Document all three current ELB types (ALB, NLB, GWLB) with layer, protocol, and use case comparisons
- Cover Auto Scaling Groups with all four scaling strategies (manual, dynamic, scheduled, predictive)
- Include ASG and ELB integration details (health checks, instance warmup, multi-AZ deployment)
- Add Shared Responsibility Model and Best Practices sections

IMPACT
- Provides exam-focused reference material with verified facts from official AWS documentation (2026-03-06)
- Clarifies commonly confused concepts (scalability vs elasticity vs agility)
- Documents deprecated features (Classic Load Balancer, launch configurations)
- 338 lines of structured content with auto-generated Table of Contents