### PR TITLE
docs(s3): add comprehensive AWS S3 study notes

### DIFF
--- a/aws-cloud-practitioner/s3.md
+++ b/aws-cloud-practitioner/s3.md
@@ -134,7 +134,7 @@ S3 stores objects (files) in buckets (containers). [Objects](https://docs.aws.am
 | Component | Description | Limits |
 | :--- | :--- | :--- |
 | **Key** | Full path (prefix + object name) | Up to 1,024 bytes UTF-8 |
-| **Value** | Object content | Max [50 TB](https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html) (increased from 5 TB in Dec 2025) |
+| **Value** | Object content | Max [50 TB](https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html) (increased from 5 TB on Dec 2, 2025) |
 | **Metadata** | System and user-defined key-value pairs | 2 KB for user metadata |
 | **Tags** | Key-value pairs for lifecycle and access | Up to [10 tags](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html) per object |
 | **Version ID** | System-assigned identifier | Only when versioning enabled |
@@ -166,11 +166,11 @@ Directories are an abstraction - S3 uses a flat namespace where the key `photos/
 | **S3 Standard-IA** | 99.999999999% | 99.9% | ≥3 | 30 days | Per-GB | Infrequent but rapid access |
 | **S3 One Zone-IA** | 99.999999999% | 99.5% | 1 | 30 days | Per-GB | Secondary backup copies |
 | **S3 Express One Zone** | 99.999999999% | 99.95% | 1 | 1 hour | Per-GB | Performance-critical |
-| **S3 Glacier Instant** | 99.999999999% | 99.9% | ≥3 | 90 days | Per-GB | Archive with millisecond access |
-| **S3 Glacier Flexible** | 99.999999999% | 99.99%* | ≥3 | 90 days | Per-GB | Archive with hours retrieval |
+| **S3 Glacier Instant Retrieval** | 99.999999999% | 99.9% | ≥3 | 90 days | Per-GB | Archive with millisecond access |
+| **S3 Glacier Flexible Retrieval** | 99.999999999% | 99.99%* | ≥3 | 90 days | Per-GB | Archive with hours retrieval |
 | **S3 Glacier Deep Archive** | 99.999999999% | 99.99%* | ≥3 | 180 days | Per-GB | Long-term archive |
 
-*After restore operation completes
+Note: Availability values marked with * apply after the restore operation completes.
 
 See [S3 storage classes](https://aws.amazon.com/s3/storage-classes/) and [S3 pricing](https://aws.amazon.com/s3/pricing/) for current details.
 
@@ -185,7 +185,7 @@ All S3 storage classes provide 11 nines (99.999999999%) durability. Data is stor
 
 ### Glacier Retrieval Options
 
-| Tier | Glacier Flexible | Glacier Deep Archive | Cost |
+| Tier | Glacier Flexible Retrieval | Glacier Deep Archive | Cost |
 | :--- | :--- | :--- | :--- |
 | **Expedited** | 1-5 minutes | Not available | Premium |
 | **Standard** | 3-5 hours | 12 hours | Standard |
@@ -223,7 +223,9 @@ Objects smaller than 128 KB are not monitored and always remain in the Frequent 
 | **Bucket Policies** | Resource-based | Cross-account access, public access, resource-level control |
 | **ACLs** | Object/bucket level | Legacy - AWS recommends disabling |
 
-[Access evaluation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-auth-workflow-bucket-operation.html): Request is allowed if (IAM policy allows OR bucket policy allows) AND no explicit DENY exists.
+[Access evaluation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-auth-workflow-bucket-operation.html): Within a single account, a request is allowed if (an IAM identity-based policy allows OR a bucket policy allows) AND no explicit DENY exists.
+
+For [cross-account access](https://docs.aws.amazon.com/AmazonS3/latest/userguide/how-s3-evaluates-access-control.html), you need both an allow in the requester's IAM identity-based policy AND an allow in the bucket's resource-based policy, and there must be no explicit DENY in any applicable policy.
 
 AWS recommends using [Bucket owner enforced](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html) Object Ownership setting (default for new buckets) which disables ACLs.
 
@@ -263,7 +265,7 @@ AWS recommends using [Bucket owner enforced](https://docs.aws.amazon.com/AmazonS
 | Block new public ACLs | `BlockPublicAcls` | Prevents creating new public ACLs |
 | Ignore all public ACLs | `IgnorePublicAcls` | Treats all ACLs as non-public |
 | Block new public policies | `BlockPublicPolicy` | Rejects bucket policies allowing public access |
-| Block public and cross-account | `RestrictPublicBuckets` | Restricts access to authorized users only |
+| Block public and cross-account | `RestrictPublicBuckets` | When bucket has a public policy, restricts access to AWS service principals and authorized users within the bucket owner account; blocks all cross-account access including explicitly granted permissions |
 
 **Important**: Disabling Block Public Access does _not_ automatically make a bucket public - you must still explicitly create a policy granting public access. "CAN be public" does not equal "IS public."
 
@@ -326,8 +328,8 @@ Suspending versioning does _not_ delete existing versions - they remain accessib
 
 | Type | Buckets Location | Data Transfer Charges | Use Cases |
 | :--- | :--- | :--- | :--- |
-| **CRR** (Cross-Region) | Different AWS Regions | Yes | Compliance, latency reduction, disaster recovery |
-| **SRR** (Same-Region) | Same AWS Region | No | Log aggregation, prod/test sync, data sovereignty |
+| **CRR** (Cross-Region) | Different AWS Regions | Yes (inter-region data transfer, replication requests, storage) | Compliance, latency reduction, disaster recovery |
+| **SRR** (Same-Region) | Same AWS Region | No inter-region data transfer (replication requests and storage charges still apply) | Log aggregation, prod/test sync, data sovereignty |
 
 **Requirements**:
 
@@ -356,7 +358,7 @@ S3 can host [static websites](https://docs.aws.amazon.com/AmazonS3/latest/usergu
 5. Configure index document (e.g., `index.html`)
 6. Optionally configure error document (e.g., `404.html`)
 
-**Website endpoint format**: `bucket-name.s3-website-region.amazonaws.com`
+**Website endpoint format**: Varies by region - either `bucket-name.s3-website-Region.amazonaws.com` (dash format, e.g., us-west-2) or `bucket-name.s3-website.Region.amazonaws.com` (dot format, e.g., ap-south-1). See [website endpoints documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteEndpoints.html) for region-specific formats.
 
 **Common 403 error causes**:
 
@@ -364,7 +366,12 @@ S3 can host [static websites](https://docs.aws.amazon.com/AmazonS3/latest/usergu
 - Missing or incorrect bucket policy
 - Incorrect resource ARN in policy (should be `arn:aws:s3:::bucket-name/*`)
 
-**HTTPS limitation**: S3 website endpoints only support HTTP. For HTTPS, use [Amazon CloudFront](https://docs.aws.amazon.com/AmazonS3/latest/userguide/website-hosting-cloudfront-walkthrough.html) with Origin Access Control (OAC).
+**HTTPS and CloudFront patterns**:
+
+- S3 website endpoints are [HTTP-only](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteEndpoints.html) and [cannot be used with CloudFront Origin Access Control (OAC)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html)
+- For HTTPS with a private bucket, use CloudFront in front of the S3 REST endpoint (e.g., `bucket-name.s3.region.amazonaws.com`) with OAC, and configure default root object and custom error responses at CloudFront for index and error routing
+- If using the S3 website endpoint directly for its built-in index and error document features, your bucket must be publicly accessible and content will only be available over HTTP
+- Recommended: Use [AWS Amplify Hosting](https://docs.aws.amazon.com/amplify/latest/userguide/welcome.html) for fully managed static website hosting with HTTPS via CloudFront
 
 > [↑ Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
closes #12

CHANGES
- Add comprehensive Amazon S3 study notes covering Cloud Practitioner exam topics
- Document four S3 bucket types (General Purpose, Directory, Table, Vector)
- Include detailed storage classes comparison with durability and availability metrics
- Cover S3 security mechanisms (IAM policies, bucket policies, Block Public Access, encryption)
- Explain versioning, replication (CRR/SRR), and lifecycle policies
- Document data migration options (Snow Family, Storage Gateway)
- Include static website hosting configuration and HTTPS limitations
- Add best practices and shared responsibility model details
- Provide inline links to official AWS documentation for verification

IMPACT
- Provides fact-checked, exam-focused S3 reference with official AWS documentation links
- Covers all S3 topics expected for AWS Certified Cloud Practitioner exam